### PR TITLE
APIs available in the cloudFile preferences UI

### DIFF
--- a/apiList/manifest.json
+++ b/apiList/manifest.json
@@ -12,6 +12,10 @@
       "background.js"
     ]
   },
+    "cloud_file": {
+    "name": "__MSG_extensionName__",
+    "management_url": "apis.html"
+  },
   "permissions": [
     "accountsRead",
     "activeTab",


### PR DESCRIPTION
It took me an hour to find out, why I couldn't open an auhentication url in a seperate tab ;-)

This change adds a cloudFile provider that shows the available APIs in its preferences ui.