### PR TITLE
Add a extension to demonstrate migrating legacy prefs to local storage

### DIFF
--- a/legacyPrefMigration/background.js
+++ b/legacyPrefMigration/background.js
@@ -1,0 +1,56 @@
+// This is the current "migration" version. You can increase it later
+// if you happen to need to do more pref (or maybe other migrations) only once
+// for a user.
+const kCurrentLegacyMigration = 1;
+
+// This is the list of defaults for the legacy preferences. Note, you only
+// need to handle the defaults here. Regardless of if there are preferences
+// to be migrated or not, these values will be saved if the preference doesn't
+// exist.
+const kPrefDefaults = {
+  bool_pref: false,
+  integer_pref: 23,
+  ascii_string_pref: "default",
+  unicode_string_pref: "",
+};
+
+async function migratePrefs() {
+  // You could use any sub-section that you want here, it doesn't have
+  // to be called "preferences".
+  const results = await browser.storage.local.get("preferences");
+
+  const currentMigration =
+    results.preferences && results.preferences.migratedLegacy
+      ? results.preferences.migratedLegacy
+      : 0;
+
+  if (currentMigration >= kCurrentLegacyMigration) {
+    return;
+  }
+
+  let prefs = results.preferences || {};
+
+  if (currentMigration < 1) {
+    for (const prefName of Object.getOwnPropertyNames(kPrefDefaults)) {
+      prefs[prefName] = await browser.myapi.getPref(prefName);
+      if (prefs[prefName] === undefined) {
+        prefs[prefName] = kPrefDefaults[prefName];
+      }
+    }
+  }
+
+  prefs.migratedLegacy = kCurrentLegacyMigration;
+  await browser.storage.local.set({ preferences: prefs });
+}
+
+// This is just a debug wrapper so you can see it in action. You could call
+// `migratePrefs().catch(console.error);` directly.
+async function main() {
+  // This triggers the migration.
+  await migratePrefs();
+
+  const results = await browser.storage.local.get("preferences");
+  console.log({ results });
+}
+
+main().catch(console.error);

--- a/legacyPrefMigration/implementation.js
+++ b/legacyPrefMigration/implementation.js
@@ -1,0 +1,68 @@
+/* eslint-disable object-shorthand */
+
+// Get various parts of the WebExtension framework that we need.
+var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
+
+// You probably already know what this does.
+var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+// This is the base preference name for all your legacy prefs.
+const MY_EXTENSION_BASE_PREF_NAME = "myaddon.";
+
+/**
+ * This maps preference names to their types. This is needed as the prefs
+ * system doesn't actually know what format you've stored your pref in.
+ */
+function prefType(name) {
+  switch (name) {
+    case "bool_pref": {
+      return "bool";
+    }
+    case "integer_pref": {
+      return "int";
+    }
+    case "ascii_string_pref": {
+      return "char";
+    }
+    case "unicode_string_pref": {
+      return "string";
+    }
+  }
+  throw new Error(`Unexpected pref type ${name}`);
+}
+
+
+// This is the important part. It implements the functions and events defined in schema.json.
+// The variable must have the same name you've been using so far, "myapi" in this case.
+var myapi = class extends ExtensionCommon.ExtensionAPI {
+  getAPI(context) {
+    return {
+      // Again, this key must have the same name.
+      myapi: {
+
+        async getPref(name) {
+          try {
+            switch (prefType(name)) {
+              case "bool": {
+                return Services.prefs.getBoolPref(`${MY_EXTENSION_BASE_PREF_NAME}${name}`);
+              }
+              case "int": {
+                return Services.prefs.getIntPref(`${MY_EXTENSION_BASE_PREF_NAME}${name}`);
+              }
+              case "char": {
+                return Services.prefs.getCharPref(`${MY_EXTENSION_BASE_PREF_NAME}${name}`);
+              }
+              case "string": {
+                return Services.prefs.getStringPref(`${MY_EXTENSION_BASE_PREF_NAME}${name}`);
+              }
+            }
+          } catch (ex) {
+            return undefined;
+          }
+          throw new Error("Unexpected pref type");
+        },
+
+      },
+    };
+  }
+};

--- a/legacyPrefMigration/manifest.json
+++ b/legacyPrefMigration/manifest.json
@@ -1,0 +1,31 @@
+{
+  "manifest_version": 2,
+  "name": "Extension containing an experimental API to migrate prefs",
+  "applications": {
+    "gecko": {
+      "id": "my@addon.org",
+      "strict_min_version": "68.0a1"
+    }
+  },
+  "version": "1",
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "permissions": ["storage"],
+  "experiment_apis": {
+    "myapi": {
+      "schema": "schema.json",
+      "parent": {
+        "scopes": [
+          "addon_parent"
+        ],
+        "paths": [
+          [
+            "myapi"
+          ]
+        ],
+        "script": "implementation.js"
+      }
+    }
+  }
+}

--- a/legacyPrefMigration/schema.json
+++ b/legacyPrefMigration/schema.json
@@ -1,0 +1,20 @@
+[
+  {
+    "namespace": "myapi",
+    "functions": [
+      {
+        "name": "getPref",
+        "type": "function",
+        "description": "Gets a preference.",
+        "async": true,
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference name"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This adds a WebExtension that demonstrates migration of the legacy preferences to local storage via the WebExtension Experiments API.