### PR TITLE
Show how to load JSM

### DIFF
--- a/experiment/implementation.js
+++ b/experiment/implementation.js
@@ -30,7 +30,7 @@ var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 // inside another JSM. 
 //
 var { ExtensionParent } = ChromeUtils.import("resource://gre/modules/ExtensionParent.jsm");
-let extension = ExtensionParent.GlobalManager.getExtension("experiment@sample.extensions.thunderbird.net")
+let extension = ExtensionParent.GlobalManager.getExtension("experiment@sample.extensions.thunderbird.net");
 var { myModule } = ChromeUtils.import(extension.getURL("modules/myModule.jsm"));
 
 // This is the important part. It implements the functions and events defined in schema.json.

--- a/experiment/manifest.json
+++ b/experiment/manifest.json
@@ -2,6 +2,11 @@
   "manifest_version": 2,
   "name": "Extension containing an experimental API",
   "version": "1",
+  "applications": {
+    "gecko": {
+      "id": "experiment@sample.extensions.thunderbird.net"
+    }
+  },
   "background": {
     "scripts": ["background.js"]
   },

--- a/experiment/modules/myModule.jsm
+++ b/experiment/modules/myModule.jsm
@@ -1,0 +1,13 @@
+var EXPORTED_SYMBOLS = ["myModule"];
+
+var myModule = {
+  value : 0,
+  incValue: function() {
+    this.value++;
+  },
+  getValue: function() {
+    return this.value;
+  },
+};
+
+console.log("Loading myModule.jsm");


### PR DESCRIPTION
Attempt number two. Added a comment explaining the situation and using the the module as a click counter.

Before merging, I would learn more about the unloading. How do I detect unloading in a WebExtension? I played around with the onUpdate and onUninstall events for WebExtensions API but those do not work for experiments, only for core APIs. 

Is there another way to fire an event on add-on unload? Otherwise I would add a comment about the caching issue.