### PR TITLE
Fix usage of extension.getURL() on unload and purge caches

### DIFF
--- a/experiment/implementation.js
+++ b/experiment/implementation.js
@@ -73,6 +73,11 @@ var myapi = class extends ExtensionCommon.ExtensionAPI {
     // remember this version of the module and continue to use it, even if your extension receives
     // an update.) You should *always* unload JSMs provided by your extension.
     Cu.unload(extension.rootURI.resolve("modules/myModule.jsm"));
+
+    // Thunderbird might still cache some of your JavaScript files and even if JSMs have been unloaded,
+    // the last used version could be reused on next load, ignoring any changes. Get around this issue
+    // by invalidating the caches (this is identical to restarting TB with the -purgecaches parameter):
+    Services.obs.notifyObservers(null, "startupcache-invalidate", null);    
   }
 };
 

--- a/experiment/implementation.js
+++ b/experiment/implementation.js
@@ -72,7 +72,7 @@ var myapi = class extends ExtensionCommon.ExtensionAPI {
     // load it afresh next time `import` is called. (If you don't call `unload`, Thunderbird will
     // remember this version of the module and continue to use it, even if your extension receives
     // an update.) You should *always* unload JSMs provided by your extension.
-    Cu.unload(extension.getURL("modules/myModule.jsm"));
+    Cu.unload(extension.rootURI.resolve("modules/myModule.jsm"));
   }
 };
 


### PR DESCRIPTION
A JSM must be unloaded using the same URL type as it has been loaded with, otherwise it has no effect.

I also added a hint about purging caches